### PR TITLE
Reuse collision list via ThreadLocal

### DIFF
--- a/server/mope/src/main/java/me/yesd/World/Collision/Collision.java
+++ b/server/mope/src/main/java/me/yesd/World/Collision/Collision.java
@@ -17,6 +17,8 @@ public class Collision {
 
     private Room room;
     private QuadTree tree;
+    private static final ThreadLocal<List<GameObject>> RETURN_OBJECTS =
+            ThreadLocal.withInitial(ArrayList::new);
 
     public Collision(Room room) {
         this.room = room;
@@ -39,10 +41,11 @@ public class Collision {
 
         // Calculate
         Iterator<Map.Entry<Integer, GameObject>> objectsIterator2 = objectsSet.iterator();
+        List<GameObject> returnObjects = RETURN_OBJECTS.get();
         while (objectsIterator2.hasNext()) {
             Map.Entry<Integer, GameObject> entry = objectsIterator2.next();
             GameObject o = entry.getValue();
-            List<GameObject> returnObjects = new ArrayList<>();
+            returnObjects.clear();
             tree.retrieve(returnObjects, o);
             o.update();
 
@@ -52,6 +55,7 @@ public class Collision {
                 }
             }
         }
+        returnObjects.clear();
     }
 
     private static void impulseCollision(GameObject obj1, GameObject obj2) {


### PR DESCRIPTION
## Summary
- Reuse a thread-local list in `Collision.update` to avoid per-iteration allocations.
- Clear and recycle the list between collision checks.

## Testing
- `mvn -q -f server/mope/pom.xml test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fc3a16cc832b876aba23e4dd1a4a