### PR TITLE
Refactor animal status flags into StatusEffect enum

### DIFF
--- a/server/mope/src/main/java/me/yesd/World/Objects/Animals/Animal.java
+++ b/server/mope/src/main/java/me/yesd/World/Objects/Animals/Animal.java
@@ -1,6 +1,7 @@
 package me.yesd.World.Objects.Animals;
 
 import java.util.Date;
+import java.util.EnumSet;
 
 import me.yesd.Constants;
 import me.yesd.Sockets.FlagWriter;
@@ -36,59 +37,7 @@ public class Animal extends GameObject {
     private boolean diveRecharging = false;
     private boolean diveActive = false;
 
-    public boolean flag_lowWat;
-    public boolean flag_inHomeBiome;
-    public boolean flag_underWater;
-    public boolean flag_eff_invincible;
-    public boolean flag_usingAbility;
-    public boolean flag_tailBitten;
-    public boolean flag_eff_stunned;
-    public boolean flag_iceSliding;
-    public boolean flag_eff_frozen;
-    public boolean flag_eff_onFire;
-    public boolean flag_eff_healing;
-    public boolean flag_eff_poison;
-    public boolean flag_constricted;
-    public boolean flag_webStuck;
-    public boolean flag_dirtStuck;
-    public boolean flag_stealth;
-    public boolean flag_eff_bleeding;
-    public boolean flag_flying;
-    public boolean flag_isGrabbed;
-    public boolean flag_eff_aniInClaws;
-    public boolean flag_eff_stunk;
-    public boolean flag_cold;
-    public boolean flag_inWater;
-    public boolean flag_inLava;
-    public boolean flag_canClimbHill;
-    public boolean flag_isClimbingHill;
-    public boolean flag_isDevMode;
-    public boolean flag_eff_slimed;
-    public boolean flag_eff_wobbling;
-    public boolean flag_eff_hot;
-    public boolean flag_eff_sweatPoisoned;
-    public boolean flag_eff_shivering;
-    public boolean flag_inHidingHole;
-    public boolean flag_eff_grabbedByFlytrap;
-    public boolean flag_eff_aloeveraHealing;
-    public boolean flag_eff_tossedInAir;
-    public boolean flag_eff_isOnSpiderWeb;
-    public boolean flag_fliesLikeDragon;
-    public boolean flag_eff_isInMud;
-    public boolean flag_eff_statue;
-    public boolean flag_eff_isOnTree;
-    public boolean flag_eff_isUnderTree;
-    public boolean flag_speared;
-    public boolean flag_eff_dirty;
-    public boolean flag_eff_virusInfection;
-    public boolean flag_eff_wearingMask;
-    public boolean flag_eff_sanitized;
-    public boolean flag_viewing1v1Invite;
-    public boolean flag_ytmode;
-    public boolean flag_zombieInfection;
-    public boolean effecT_isZombie;
-
-    private boolean canClimbHills = false;
+    private EnumSet<StatusEffect> statusEffects = StatusEffect.none();
 
     private double targetAngle = 0;
 
@@ -112,11 +61,22 @@ public class Animal extends GameObject {
     }
 
     public void setCanClimbHills(boolean a) {
-        this.canClimbHills = a;
+        setStatus(StatusEffect.CAN_CLIMB_HILL, a);
     }
 
     public boolean getCanClimbHills() {
-        return this.canClimbHills;
+        return hasStatus(StatusEffect.CAN_CLIMB_HILL);
+    }
+
+    public boolean hasStatus(StatusEffect effect) {
+        return this.statusEffects.contains(effect);
+    }
+
+    public void setStatus(StatusEffect effect, boolean value) {
+        if (value)
+            this.statusEffects.add(effect);
+        else
+            this.statusEffects.remove(effect);
     }
 
     public AnimalInfo getInfo() {
@@ -180,9 +140,9 @@ public class Animal extends GameObject {
 
         if (godMode) {
             if (godmode_time > new Date().getTime()) {
-                this.flag_eff_invincible = true;
+                setStatus(StatusEffect.EFF_INVINCIBLE, true);
             } else {
-                this.flag_eff_invincible = false;
+                setStatus(StatusEffect.EFF_INVINCIBLE, false);
                 godMode = false;
             }
         }
@@ -316,68 +276,68 @@ public class Animal extends GameObject {
         // flags
         FlagWriter flagWriter = new FlagWriter();
 
-        flagWriter.writeBoolean(this.flag_lowWat);
-        flagWriter.writeBoolean(this.flag_inHomeBiome);
-        flagWriter.writeBoolean(this.flag_underWater);
-        flagWriter.writeBoolean(this.flag_eff_invincible);
+        flagWriter.writeBoolean(hasStatus(StatusEffect.LOW_WATER));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.IN_HOME_BIOME));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.UNDER_WATER));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_INVINCIBLE));
         flagWriter.writeBoolean(this.getInfo().getAbility() != null ? this.getInfo().getAbility().isActive() : false);
-        flagWriter.writeBoolean(this.flag_tailBitten);
-        flagWriter.writeBoolean(this.flag_eff_stunned);
-        flagWriter.writeBoolean(this.flag_iceSliding);
-        flagWriter.writeBoolean(this.flag_eff_frozen);
-        flagWriter.writeBoolean(this.flag_eff_onFire);
-        flagWriter.writeBoolean(this.flag_eff_healing);
-        flagWriter.writeBoolean(this.flag_eff_poison);
-        flagWriter.writeBoolean(this.flag_constricted);
-        flagWriter.writeBoolean(this.flag_webStuck);
-        flagWriter.writeBoolean(this.flag_stealth);
-        flagWriter.writeBoolean(this.flag_eff_bleeding);
-        flagWriter.writeBoolean(this.flag_flying);
-        flagWriter.writeBoolean(this.flag_isGrabbed);
-        flagWriter.writeBoolean(this.flag_eff_aniInClaws);
-        flagWriter.writeBoolean(this.flag_eff_stunk);
-        flagWriter.writeBoolean(this.flag_cold);
-        flagWriter.writeBoolean(this.flag_inWater);
-        flagWriter.writeBoolean(this.flag_inLava);
-        flagWriter.writeBoolean(this.canClimbHills);
-        flagWriter.writeBoolean(this.flag_isDevMode);
-        flagWriter.writeBoolean(this.flag_eff_slimed);
-        flagWriter.writeBoolean(this.flag_eff_wobbling);
-        flagWriter.writeBoolean(this.flag_eff_hot);
-        flagWriter.writeBoolean(this.flag_eff_sweatPoisoned);
-        flagWriter.writeBoolean(this.flag_eff_shivering);
+        flagWriter.writeBoolean(hasStatus(StatusEffect.TAIL_BITTEN));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_STUNNED));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.ICE_SLIDING));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_FROZEN));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_ON_FIRE));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_HEALING));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_POISON));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.CONSTRICTED));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.WEB_STUCK));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.STEALTH));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_BLEEDING));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.FLYING));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.IS_GRABBED));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_ANI_IN_CLAWS));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_STUNK));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.COLD));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.IN_WATER));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.IN_LAVA));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.CAN_CLIMB_HILL));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.IS_DEV_MODE));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_SLIMED));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_WOBBLING));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_HOT));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_SWEAT_POISONED));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_SHIVERING));
         flagWriter.writeBoolean(false); // in hole
-        flagWriter.writeBoolean(this.flag_eff_grabbedByFlytrap);
-        flagWriter.writeBoolean(this.flag_eff_aloeveraHealing);
-        flagWriter.writeBoolean(this.flag_eff_tossedInAir);
-        flagWriter.writeBoolean(this.flag_eff_isOnSpiderWeb);
-        flagWriter.writeBoolean(this.flag_fliesLikeDragon);
-        flagWriter.writeBoolean(this.flag_eff_isInMud);
-        flagWriter.writeBoolean(this.flag_eff_statue);
-        flagWriter.writeBoolean(this.flag_eff_isOnTree);
-        flagWriter.writeBoolean(this.flag_eff_isUnderTree);
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_GRABBED_BY_FLYTRAP));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_ALOEVERA_HEALING));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_TOSSED_IN_AIR));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_IS_ON_SPIDER_WEB));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.FLIES_LIKE_DRAGON));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_IS_IN_MUD));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_STATUE));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_IS_ON_TREE));
+        flagWriter.writeBoolean(hasStatus(StatusEffect.EFF_IS_UNDER_TREE));
         writer.writeFlags(flagWriter);
-        writer.writeBoolean(this.flag_speared);
-        writer.writeBoolean(this.flag_eff_dirty);
+        writer.writeBoolean(hasStatus(StatusEffect.SPEARED));
+        writer.writeBoolean(hasStatus(StatusEffect.EFF_DIRTY));
         writer.writeBoolean(false); // pvp enabled
         writer.writeBoolean(false); // in arena
 
         writer.writeUInt8(0); // arena wins
         writer.writeUInt8(0); // player num
 
-        if (this.flag_isDevMode)
+        if (hasStatus(StatusEffect.IS_DEV_MODE))
             writer.writeUInt8(0); // developerModeNumber
 
-        if (this.flag_eff_statue)
+        if (hasStatus(StatusEffect.EFF_STATUE))
             writer.writeUInt8(0); // statue type
 
-        if (this.flag_constricted)
+        if (hasStatus(StatusEffect.CONSTRICTED))
             writer.writeUInt8(0); // eff_constrictedSpecies
 
-        if (this.flag_webStuck)
+        if (hasStatus(StatusEffect.WEB_STUCK))
             writer.writeUInt8(0); // eff_webStuckType
 
-        if (this.flag_eff_dirty)
+        if (hasStatus(StatusEffect.EFF_DIRTY))
             writer.writeUInt8(0); // eff_dirtType
     }
 }

--- a/server/mope/src/main/java/me/yesd/World/Objects/Animals/StatusEffect.java
+++ b/server/mope/src/main/java/me/yesd/World/Objects/Animals/StatusEffect.java
@@ -1,0 +1,67 @@
+package me.yesd.World.Objects.Animals;
+
+import java.util.EnumSet;
+
+/**
+ * Enumeration of all possible status effects that can be applied to an {@link Animal}.
+ */
+public enum StatusEffect {
+    LOW_WATER,
+    IN_HOME_BIOME,
+    UNDER_WATER,
+    EFF_INVINCIBLE,
+    USING_ABILITY,
+    TAIL_BITTEN,
+    EFF_STUNNED,
+    ICE_SLIDING,
+    EFF_FROZEN,
+    EFF_ON_FIRE,
+    EFF_HEALING,
+    EFF_POISON,
+    CONSTRICTED,
+    WEB_STUCK,
+    DIRT_STUCK,
+    STEALTH,
+    EFF_BLEEDING,
+    FLYING,
+    IS_GRABBED,
+    EFF_ANI_IN_CLAWS,
+    EFF_STUNK,
+    COLD,
+    IN_WATER,
+    IN_LAVA,
+    CAN_CLIMB_HILL,
+    IS_CLIMBING_HILL,
+    IS_DEV_MODE,
+    EFF_SLIMED,
+    EFF_WOBBLING,
+    EFF_HOT,
+    EFF_SWEAT_POISONED,
+    EFF_SHIVERING,
+    IN_HIDING_HOLE,
+    EFF_GRABBED_BY_FLYTRAP,
+    EFF_ALOEVERA_HEALING,
+    EFF_TOSSED_IN_AIR,
+    EFF_IS_ON_SPIDER_WEB,
+    FLIES_LIKE_DRAGON,
+    EFF_IS_IN_MUD,
+    EFF_STATUE,
+    EFF_IS_ON_TREE,
+    EFF_IS_UNDER_TREE,
+    SPEARED,
+    EFF_DIRTY,
+    EFF_VIRUS_INFECTION,
+    EFF_WEARING_MASK,
+    EFF_SANITIZED,
+    VIEWING_1V1_INVITE,
+    YT_MODE,
+    ZOMBIE_INFECTION,
+    EFF_IS_ZOMBIE;
+
+    /**
+     * Convenience method to create an empty set of status effects.
+     */
+    public static EnumSet<StatusEffect> none() {
+        return EnumSet.noneOf(StatusEffect.class);
+    }
+}


### PR DESCRIPTION
## Summary
- replace numerous `flag_*` boolean fields with an `EnumSet<StatusEffect>`
- add `StatusEffect` enum representing all status flags
- update status checks and serialization to use the EnumSet

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fe57d93c832b8c9e0988fd2c5c27