### PR TITLE
Gracefully handle WebSocket errors

### DIFF
--- a/server/mope/src/main/java/me/yesd/Sockets/GameServer.java
+++ b/server/mope/src/main/java/me/yesd/Sockets/GameServer.java
@@ -55,8 +55,14 @@ public class GameServer extends WebSocketServer {
 
     @Override
     public void onError(WebSocket conn, Exception ex) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'onError'");
+        ex.printStackTrace();
+        if (conn != null) {
+            try {
+                conn.close();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Log errors in `GameServer.onError` and close problematic connections safely.

## Testing
- `mvn test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a10113ee5c832bb5c34746a17334cf