### PR TITLE
Use configurable port for GameServer

### DIFF
--- a/server/mope/src/main/java/me/yesd/Sockets/GameServer.java
+++ b/server/mope/src/main/java/me/yesd/Sockets/GameServer.java
@@ -17,7 +17,7 @@ public class GameServer extends WebSocketServer {
     private Room room;
 
     public GameServer(Room room) {
-        super(new InetSocketAddress("0.0.0.0", 2255));
+        super(new InetSocketAddress("0.0.0.0", Constants.PORT));
         this.setReuseAddr(true);
         if (Constants.USINGSSL) {
             this.setWebSocketFactory(new DefaultSSLWebSocketServerFactory(SSL.getContext()));


### PR DESCRIPTION
## Summary
- use `Constants.PORT` in `GameServer` so the server listens on the configured port instead of hard-coded 2255

## Testing
- `mvn -q -f server/mope/pom.xml test` *(fails: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a101192030832baefa7e68257af20a