### PR TITLE
Unify string message format

### DIFF
--- a/server/mope/src/main/java/me/yesd/Sockets/MsgReader.java
+++ b/server/mope/src/main/java/me/yesd/Sockets/MsgReader.java
@@ -2,6 +2,7 @@ package me.yesd.Sockets;
 
 import me.yesd.Utilities.PacketException;
 import me.yesd.Utilities.Utilities;
+import java.nio.charset.StandardCharsets;
 
 public class MsgReader {
     private int offset;
@@ -55,11 +56,11 @@ public class MsgReader {
     }
 
     public String readString() throws PacketException {
-        StringBuilder sb = new StringBuilder();
         int length = this.readUInt16();
+        byte[] bytes = new byte[length];
         for (int i = 0; i < length; ++i) {
-            sb.append((char) this.readUInt8());
+            bytes[i] = (byte) this.readUInt8();
         }
-        return Utilities.decode_utf8(sb.toString());
+        return Utilities.decode_utf8(new String(bytes, StandardCharsets.UTF_8));
     }
 }

--- a/server/mope/src/main/java/me/yesd/Sockets/MsgWriter.java
+++ b/server/mope/src/main/java/me/yesd/Sockets/MsgWriter.java
@@ -60,13 +60,11 @@ public class MsgWriter {
 
     public void writeString(String string) {
         string = Utilities.encode_utf8(string);
-        writeUInt16((short) (string.length() + 1));
+        writeUInt16((short) string.length());
 
         for (int i = 0; i < string.length(); ++i) {
             writeByte((byte) string.charAt(i));
         }
-
-        writeByte((byte) 109);
     }
 
     public byte[] getData() {

--- a/server/mope/src/test/java/me/yesd/Sockets/MsgReaderWriterTest.java
+++ b/server/mope/src/test/java/me/yesd/Sockets/MsgReaderWriterTest.java
@@ -1,0 +1,18 @@
+package me.yesd.Sockets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import me.yesd.Utilities.PacketException;
+
+public class MsgReaderWriterTest {
+    @Test
+    void roundTripString() throws PacketException {
+        String original = "Привет";
+        MsgWriter writer = new MsgWriter();
+        writer.writeString(original);
+        MsgReader reader = new MsgReader(writer.getData());
+        assertEquals(original, reader.readString());
+    }
+}


### PR DESCRIPTION
## Summary
- Write string data with precise length and no trailing terminator
- Read strings based on declared length and decode bytes using UTF-8
- Add unit test ensuring MsgWriter and MsgReader exchange strings correctly

## Testing
- `MAVEN_OPTS='-Djava.net.preferIPv4Stack=true' mvn -q -f server/mope/pom.xml test` (fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)
- `java -cp /tmp/testsrc TestRoundTrip`


------
https://chatgpt.com/codex/tasks/task_e_68a101208f90832ba12bd4766d5f9a25