### PR TITLE
Change PacketException to extend Exception

### DIFF
--- a/server/mope/src/main/java/me/yesd/Utilities/PacketException.java
+++ b/server/mope/src/main/java/me/yesd/Utilities/PacketException.java
@@ -1,6 +1,6 @@
 package me.yesd.Utilities;
 
-public class PacketException extends Throwable {
+public class PacketException extends Exception {
     static final long serialVersionUID = -3387516993124229948L;
 
     public PacketException() {

--- a/server/mope/src/main/java/me/yesd/World/Objects/Client/GameClient.java
+++ b/server/mope/src/main/java/me/yesd/World/Objects/Client/GameClient.java
@@ -173,7 +173,7 @@ public class GameClient {
                 default:
                     break;
             }
-        } catch (Exception | PacketException e) {
+        } catch (Exception e) {
             e.printStackTrace();
             this.sendDisconnect("MOPERR_000");
         }


### PR DESCRIPTION
## Summary
- Make `PacketException` extend `Exception` instead of `Throwable`
- Adjust GameClient message handling to catch `Exception` uniformly

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1012244b0832b9147aa260987c836