### PR TITLE
Handle missing clients in GameServer

### DIFF
--- a/server/mope/src/main/java/me/yesd/Sockets/GameServer.java
+++ b/server/mope/src/main/java/me/yesd/Sockets/GameServer.java
@@ -34,7 +34,12 @@ public class GameServer extends WebSocketServer {
 
     @Override
     public void onClose(WebSocket conn, int code, String reason, boolean remote) {
-        room.getClient(conn).onClose();
+        GameClient client = room.getClient(conn);
+        if (client != null) {
+            client.onClose();
+        } else {
+            System.out.println("Client not found on close: " + conn);
+        }
         room.removeClient(conn);
         System.out.println("deacc");
     }
@@ -47,7 +52,12 @@ public class GameServer extends WebSocketServer {
     @Override
     public void onMessage(WebSocket conn, final ByteBuffer blob) {
         try {
-            room.getClient(conn).onMessage(blob.array());
+            GameClient client = room.getClient(conn);
+            if (client != null) {
+                client.onMessage(blob.array());
+            } else {
+                System.out.println("Client not found for message: " + conn);
+            }
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
## Summary
- guard `GameServer` actions with null checks when retrieving a room client
- log missing client situations on close and message handling

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a101235ac8832bb953cb27db66fa51