### PR TITLE
refactor: use ReentrantReadWriteLock in QuadTree

### DIFF
--- a/server/mope/src/main/java/me/yesd/World/Collision/QuadTree/QuadTree.java
+++ b/server/mope/src/main/java/me/yesd/World/Collision/QuadTree/QuadTree.java
@@ -2,7 +2,6 @@ package me.yesd.World.Collision.QuadTree;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import me.yesd.World.Objects.GameObject;
@@ -15,7 +14,7 @@ public class QuadTree {
     private final List<GameObject> objects;
     private final Rectangle bounds;
     private final QuadTree[] nodes;
-    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
     public QuadTree(int pLevel, Rectangle pBounds) {
         level = pLevel;


### PR DESCRIPTION
## Summary
- replace generic ReadWriteLock with ReentrantReadWriteLock in QuadTree to enable thread ownership checks

## Testing
- `mvn -q -e -f server/mope/pom.xml -DskipTests package` *(fails: Network is unreachable)*
- `javac -cp server/mope/src/main/java:lib/commons-text-1.10.0.jar -d /tmp/classes server/mope/src/main/java/me/yesd/World/Collision/QuadTree/QuadTree.java`

------
https://chatgpt.com/codex/tasks/task_e_68a1f66bf580832bbfab756d6b208cad