### PR TITLE
Fix QuadTree midpoint calculations

### DIFF
--- a/server/mope/src/main/java/me/yesd/World/Collision/QuadTree/QuadTree.java
+++ b/server/mope/src/main/java/me/yesd/World/Collision/QuadTree/QuadTree.java
@@ -56,8 +56,8 @@ public class QuadTree {
     // Determine which node the object belongs to.
     private ArrayList<Integer> getIndex(GameObject circle) {
         ArrayList<Integer> index = new ArrayList<>();
-        double verticalMidpoint = bounds.getX() + (bounds.getWidth());
-        double horizontalMidpoint = bounds.getY() + (bounds.getHeight());
+        double verticalMidpoint = bounds.getX() + bounds.getWidth() / 2.0;
+        double horizontalMidpoint = bounds.getY() + bounds.getHeight() / 2.0;
 
         // Object can completely fit within the top quadrants
         boolean topQuadrant = (circle.getY() < horizontalMidpoint


### PR DESCRIPTION
## Summary
- fix vertical and horizontal midpoint calculations in `QuadTree.getIndex`

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68a1f66c42c0832bbe40f0b59181e856